### PR TITLE
supply metadata files in .git directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ git config --get pullrequest.id         # returns the ID number of the PR
 git config --get pullrequest.basebranch # returns the base branch used for the pull request
 ```
 
+
+#### Additional files populated
+
+ * `.git/id`: the pull request id
+
+ * `.git/url`: the URL for the pull request
+
+ * `.git/branch`: the branch associated with the pull request
+
+ * `.git/base_branch`: the base branch of the pull request
+
 #### Parameters
 
 * `git.depth`: *Optional.* If a positive integer is given, *shallow* clone the

--- a/assets/lib/commands/in.rb
+++ b/assets/lib/commands/in.rb
@@ -10,7 +10,6 @@ module Commands
 
     def initialize(destination:, input: Input.instance)
       @destination = destination
-      @src_destination = "#{@destination}/src"
 
       super(input: input)
     end
@@ -21,11 +20,11 @@ module Commands
 
       raise 'PR has merge conflicts' if pr['mergeable'] == false && fetch_merge
 
-      system("git clone #{depth_flag} #{uri} #{@src_destination} 1>&2")
+      system("git clone #{depth_flag} #{uri} #{destination} 1>&2")
 
       raise 'git clone failed' unless $CHILD_STATUS.exitstatus.zero?
 
-      Dir.chdir(@destination) do
+      Dir.chdir(File.join(destination,'.git')) do
         system <<-BASH
           echo "#{pr['html_url']}" > url
           echo "#{pr['number']}" > id
@@ -34,7 +33,7 @@ module Commands
         BASH
       end
 
-      Dir.chdir(@src_destination) do
+      Dir.chdir(destination) do
         raise 'git clone failed' unless system("git fetch -q origin pull/#{id}/#{remote_ref}:#{branch_ref} 1>&2")
 
         system <<-BASH

--- a/spec/commands/in_spec.rb
+++ b/spec/commands/in_spec.rb
@@ -87,6 +87,27 @@ describe Commands::In do
         value = git('config pullrequest.basebranch', dest_dir)
         expect(value).to eq 'master'
       end
+
+      it 'creates a file that icludes the id in the .git folder' do
+        value = File.read(File.join(dest_dir,'.git','id')).strip()
+        expect(value).to eq '1'
+      end
+
+      it 'creates a file that icludes the url in the .git folder' do
+        value = File.read(File.join(dest_dir,'.git','url')).strip()
+        expect(value).to eq 'http://example.com'
+      end
+
+      it 'creates a file that icludes ahe branch in the .git folder' do
+        value = File.read(File.join(dest_dir,'.git','branch')).strip()
+        expect(value).to eq 'foo'
+      end
+
+      it 'creates a file that icludes the base_branch in the .git folder' do
+        value = File.read(File.join(dest_dir,'.git','base_branch')).strip()
+        expect(value).to eq 'master'
+      end
+
     end
 
     context 'when the git clone fails' do

--- a/spec/commands/in_spec.rb
+++ b/spec/commands/in_spec.rb
@@ -13,7 +13,6 @@ describe Commands::In do
   end
 
   let(:dest_dir) { Dir.mktmpdir }
-  let(:src_dest_dir) { "#{dest_dir}/src" }
 
   def get(payload)
     payload['source']['no_ssl_verify'] = true
@@ -52,17 +51,13 @@ describe Commands::In do
         @dest_dir ||= Dir.mktmpdir
       end
 
-      def src_dest_dir
-        @src_dest_dir ||= "#{dest_dir}/src"
-      end
-
       before(:all) do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' })
         @output = get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' })
       end
 
-      it 'checks out the pull request to src_dest_dir' do
-        expect(@ref).to eq git('log --format=format:%H HEAD', src_dest_dir)
+      it 'checks out the pull request to dest_dir' do
+        expect(@ref).to eq git('log --format=format:%H HEAD', dest_dir)
       end
 
       it 'returns the correct JSON metadata' do
@@ -74,22 +69,22 @@ describe Commands::In do
       end
 
       it 'adds metadata to `git config`' do
-        value = git('config --get pullrequest.url', src_dest_dir)
+        value = git('config --get pullrequest.url', dest_dir)
         expect(value).to eq 'http://example.com'
       end
 
       it 'checks out as a branch with a `pr-` prefix' do
-        value = git('rev-parse --abbrev-ref HEAD', src_dest_dir)
+        value = git('rev-parse --abbrev-ref HEAD', dest_dir)
         expect(value).to eq 'pr-foo'
       end
 
       it 'sets config variable to branch name' do
-        value = git('config pullrequest.branch', src_dest_dir)
+        value = git('config pullrequest.branch', dest_dir)
         expect(value).to eq 'foo'
       end
 
       it 'sets config variable to base_branch name' do
-        value = git('config pullrequest.basebranch', src_dest_dir)
+        value = git('config pullrequest.basebranch', dest_dir)
         expect(value).to eq 'master'
       end
     end
@@ -113,7 +108,7 @@ describe Commands::In do
 
         get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => false })
 
-        value = git('rev-parse --abbrev-ref HEAD', src_dest_dir)
+        value = git('rev-parse --abbrev-ref HEAD', dest_dir)
         expect(value).to eq 'pr-foo'
       end
 
@@ -134,7 +129,7 @@ describe Commands::In do
 
         get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params:' => { 'fetch_merge' => true })
 
-        value = git('rev-parse --abbrev-ref HEAD', src_dest_dir)
+        value = git('rev-parse --abbrev-ref HEAD', dest_dir)
         expect(value).to eq 'pr-foo'
       end
 

--- a/spec/integration/in_spec.rb
+++ b/spec/integration/in_spec.rb
@@ -7,7 +7,6 @@ describe 'get' do
 
   let(:proxy) { Billy::Proxy.new }
   let(:dest_dir) { Dir.mktmpdir }
-  let(:src_dest_dir) { "#{dest_dir}/src" }
   let(:git_dir)  { Dir.mktmpdir }
   let(:git_uri)  { "file://#{git_dir}" }
 
@@ -39,9 +38,9 @@ describe 'get' do
            .and_return(json: { html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' } })
     end
 
-    it 'checks out the pull request to src_dest_dir' do
+    it 'checks out the pull request to dest_dir' do
       get(version: { ref: @ref, pr: '1' }, source: { access_token: 'abc', uri: git_uri, repo: 'jtarchie/test' })
-      expect(@ref).to eq git('log --format=format:%H HEAD', src_dest_dir)
+      expect(@ref).to eq git('log --format=format:%H HEAD', dest_dir)
     end
   end
 end

--- a/spec/integration/in_spec.rb
+++ b/spec/integration/in_spec.rb
@@ -7,6 +7,7 @@ describe 'get' do
 
   let(:proxy) { Billy::Proxy.new }
   let(:dest_dir) { Dir.mktmpdir }
+  let(:src_dest_dir) { "#{dest_dir}/src" }
   let(:git_dir)  { Dir.mktmpdir }
   let(:git_uri)  { "file://#{git_dir}" }
 
@@ -38,9 +39,9 @@ describe 'get' do
            .and_return(json: { html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' } })
     end
 
-    it 'checks out the pull request to dest_dir' do
+    it 'checks out the pull request to src_dest_dir' do
       get(version: { ref: @ref, pr: '1' }, source: { access_token: 'abc', uri: git_uri, repo: 'jtarchie/test' })
-      expect(@ref).to eq git('log --format=format:%H HEAD', dest_dir)
+      expect(@ref).to eq git('log --format=format:%H HEAD', src_dest_dir)
     end
   end
 end


### PR DESCRIPTION
 `id`, `branch`, and `base_branch` files are outputted to the `.git` directory.  These files include respective metadata

naive implementation of requested feature jtarchie/github-pullrequest-resource#99

~I do realize I haven't added any specs.  I'll look to do so tonight~ added