### PR TITLE
Include PR author user_login in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ git config --get pullrequest.url        # returns the URL to the pull request
 git config --get pullrequest.branch     # returns the branch name used for the pull request
 git config --get pullrequest.id         # returns the ID number of the PR
 git config --get pullrequest.basebranch # returns the base branch used for the pull request
+git config --get pullrequest.userlogin  # returns the github user login for the pull request author
 ```
 
 
@@ -125,10 +126,12 @@ git config --get pullrequest.basebranch # returns the base branch used for the p
 
  * `.git/base_branch`: the base branch of the pull request
 
+ * `.git/user_login`: the user login of the pull request author
+
 #### Parameters
 
 * `git.depth`: *Optional.* If a positive integer is given, *shallow* clone the
-  repository using the `--depth` option. 
+  repository using the `--depth` option.
 
 * `git.submodules`: *Optional*, default `all`. If `none`, submodules will not be
   fetched. If specified as a list of paths, only the given paths will be
@@ -158,7 +161,7 @@ Set the status message for `concourse-ci` context on specified pull request.
   This supports the [build environment](http://concourse.ci/implementing-resources.html#resource-metadata)
   variables provided by concourse. For example, `context: $BUILD_JOB_NAME` will set the context to the job name.
 
-* `comment`: *Optional.* The file path of the comment message. Comment owner is same with the owner of `access_token`. 
+* `comment`: *Optional.* The file path of the comment message. Comment owner is same with the owner of `access_token`.
 
 * `merge.method`: *Optional.* Use this to merge the PR into the target branch of the PR. There are three available merge methods -- `merge`, `squash`, or `rebase`. Please this [doc](https://developer.github.com/changes/2016-09-26-pull-request-merge-api-update/) for more information.
 
@@ -179,4 +182,3 @@ Requires `ruby` to be installed.
   bundle install
   bundle exec rspec
   ```
-

--- a/assets/lib/commands/in.rb
+++ b/assets/lib/commands/in.rb
@@ -30,6 +30,7 @@ module Commands
           echo "#{pr['number']}" > id
           echo "#{pr['head']['ref']}" > branch
           echo "#{pr['base']['ref']}" > base_branch
+          echo "#{pr['base']['user']['login']}" > userlogin
         BASH
       end
 
@@ -42,6 +43,7 @@ module Commands
           git config --add pullrequest.id #{pr['number']} 1>&2
           git config --add pullrequest.branch #{pr['head']['ref']} 1>&2
           git config --add pullrequest.basebranch #{pr['base']['ref']} 1>&2
+          git config --add pullrequest.userlogin #{pr['base']['user']['login']} 1>&2
         BASH
 
         case input.params.git.submodules

--- a/spec/commands/in_spec.rb
+++ b/spec/commands/in_spec.rb
@@ -52,7 +52,7 @@ describe Commands::In do
       end
 
       before(:all) do
-        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' })
+        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } })
         @output = get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' })
       end
 
@@ -88,6 +88,11 @@ describe Commands::In do
         expect(value).to eq 'master'
       end
 
+      it 'sets config variable to user_login name' do
+        value = git('config pullrequest.userlogin', dest_dir)
+        expect(value).to eq 'jtarchie'
+      end
+
       it 'creates a file that icludes the id in the .git folder' do
         value = File.read(File.join(dest_dir,'.git','id')).strip()
         expect(value).to eq '1'
@@ -112,7 +117,7 @@ describe Commands::In do
 
     context 'when the git clone fails' do
       it 'provides a helpful erorr message' do
-        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' })
+        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } })
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => 'invalid_git_uri', 'repo' => 'jtarchie/test' })
@@ -125,7 +130,7 @@ describe Commands::In do
     context 'and fetch_merge is false' do
       it 'checks out as a branch named in the PR' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, mergeable: true)
 
         get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => false })
 
@@ -135,7 +140,7 @@ describe Commands::In do
 
       it 'does not fail cloning' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, mergeable: true)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => false })
@@ -146,7 +151,7 @@ describe Commands::In do
     context 'and fetch_merge is true' do
       it 'checks out the branch the PR would be merged into' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, mergeable: true)
 
         get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params:' => { 'fetch_merge' => true })
 
@@ -156,7 +161,7 @@ describe Commands::In do
 
       it 'does not fail cloning' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, mergeable: true)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => true })
@@ -169,7 +174,7 @@ describe Commands::In do
     context 'and fetch_merge is true' do
       it 'raises a helpful error message' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: false)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, mergeable: false)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => true })
@@ -183,7 +188,7 @@ describe Commands::In do
       stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
                 html_url: 'http://example.com', number: 1,
                 head: { ref: 'foo' },
-                base: { ref: 'master' })
+                base: { ref: 'master', user: { login: 'jtarchie' } })
     end
 
     def expect_arg(*args)

--- a/spec/integration/in_spec.rb
+++ b/spec/integration/in_spec.rb
@@ -35,7 +35,7 @@ describe 'get' do
   context 'for every PR that is checked out' do
     before do
       proxy.stub('https://api.github.com:443/repos/jtarchie/test/pulls/1')
-           .and_return(json: { html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' } })
+           .and_return(json: { html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } } })
     end
 
     it 'checks out the pull request to dest_dir' do


### PR DESCRIPTION
Towards the possible implementation of whitelist protection in subsequent task steps before doing insecure builds/deployments

Verification from using this branch upon https://github.com/starkandwayne/concourse-pullrequest-playtime/pull/1 in https://ci.starkandwayne.com/teams/main/pipelines/concourse-pullrequest-playtime/jobs/test-pr/builds/9. Within the `test-pr` container, the `.../git-pull-requests` folder has `pullrequest.userlogin` config:

```
# git config --list
core.repositoryformatversion=0
core.filemode=true
core.bare=false
core.logallrefupdates=true
remote.origin.url=https://github.com/starkandwayne/concourse-pullrequest-playtime
remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*
branch.master.remote=origin
branch.master.merge=refs/heads/master
pullrequest.url=https://github.com/starkandwayne/concourse-pullrequest-playtime/pull/1
pullrequest.id=1
pullrequest.branch=drnic-patch-1
pullrequest.basebranch=master
pullrequest.userlogin=starkandwayne

# cat .git/userlogin
starkandwayne
```