### PR TITLE
Respect depth flag when fetching the branch

### DIFF
--- a/assets/lib/commands/in.rb
+++ b/assets/lib/commands/in.rb
@@ -36,7 +36,7 @@ module Commands
       end
 
       Dir.chdir(destination) do
-        raise 'git clone failed' unless system("git fetch -q origin pull/#{id}/#{remote_ref}:#{branch_ref} 1>&2")
+        raise 'git clone failed' unless system("git fetch #{depth_flag} -q origin pull/#{id}/#{remote_ref}:#{branch_ref} 1>&2")
 
         system <<-BASH
           git checkout #{branch_ref} 1>&2


### PR DESCRIPTION
Apply the depth flag to the branch fetch operation and not just the
initial clone.