### PR TITLE
clone base branch instead of remote default branch

### DIFF
--- a/assets/lib/commands/in.rb
+++ b/assets/lib/commands/in.rb
@@ -20,7 +20,7 @@ module Commands
 
       raise 'PR has merge conflicts' if pr['mergeable'] == false && fetch_merge
 
-      system("git clone #{depth_flag} #{uri} #{destination} 1>&2")
+      system("git clone #{depth_flag} --branch #{pr['base']['ref']} #{uri} #{destination} 1>&2")
 
       raise 'git clone failed' unless $CHILD_STATUS.exitstatus.zero?
 


### PR DESCRIPTION
Clone the base branch instead of the default remote branch. This is
mostly useful when the base branch is not the default remote branch,
especially when the depth filter is used; it ensures that the base
branch's ref is available so that it can be diffed with the branch ref.