### PR TITLE
Fixes minor typo with populated filename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ git config --get pullrequest.userlogin  # returns the github user login for the 
 
  * `.git/base_branch`: the base branch of the pull request
 
- * `.git/user_login`: the user login of the pull request author
+ * `.git/userlogin`: the user login of the pull request author
 
  * `.git/head_sha`: the latest commit hash of the branch associated with the pull request
 


### PR DESCRIPTION
This is a minor documentation fix. The file for the PR user is  listed as `./git/user_login`, but the file created is actually `./git/userlogin`.

See: https://github.com/jtarchie/github-pullrequest-resource/blob/add85a8d56d81cc4a889116d3fd81a89f270538b/assets/lib/commands/in.rb#L33