### PR TITLE
Add support for [ci skip] on outstanding PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ example/
 .bundle
 bin
 .secrets.yml
+test_pipeline.yml

--- a/assets/lib/commands/check.rb
+++ b/assets/lib/commands/check.rb
@@ -7,7 +7,9 @@ require_relative '../repository'
 module Commands
   class Check < Commands::Base
     def output
-      repo.pull_requests
+      repo.pull_requests.reject do |pr|
+        pr.latest_commit_message.include? '[ci skip]'
+      end
     end
 
     private

--- a/assets/lib/commands/check.rb
+++ b/assets/lib/commands/check.rb
@@ -7,9 +7,7 @@ require_relative '../repository'
 module Commands
   class Check < Commands::Base
     def output
-      repo.pull_requests.reject do |pr|
-        pr.latest_commit_message.include? '[ci skip]'
-      end
+      repo.pull_requests
     end
 
     private

--- a/assets/lib/filters/all.rb
+++ b/assets/lib/filters/all.rb
@@ -9,7 +9,7 @@ module Filters
 
     def pull_requests
       @pull_requests ||= Octokit.pulls(input.source.repo, pull_options).map do |pr|
-        PullRequest.new(pr: pr)
+        PullRequest.new(pr: pr, top_commit: Octokit.commit(input.source.repo, pr['head']['sha']))
       end
     end
 

--- a/assets/lib/filters/ci_skip.rb
+++ b/assets/lib/filters/ci_skip.rb
@@ -1,0 +1,16 @@
+module Filters
+  class CISkip
+    def initialize(pull_requests:, input: Input.instance)
+      @pull_requests = pull_requests
+      @input = input
+    end
+
+    def pull_requests
+      unless @input.source.disable_ci_skip
+        @memoized ||= @pull_requests.delete_if { |pr| pr.latest_commit_message =~ /\[(ci skip|skip ci)\]/ }
+      else
+        @pull_requests
+      end
+    end
+  end
+end

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -3,11 +3,13 @@ require 'octokit'
 class PullRequest
   def self.from_github(repo:, id:)
     pr = Octokit.pull_request(repo.name, id)
-    PullRequest.new(pr: pr)
+    tc = Octokit.commit(repo.name, pr['head']['sha'])
+    PullRequest.new(pr: pr, top_commit: tc)
   end
 
-  def initialize(pr:)
+  def initialize(pr:, top_commit:)
     @pr = pr
+    @top_commit = top_commit
   end
 
   def from_fork?
@@ -32,6 +34,10 @@ class PullRequest
 
   def sha
     @pr['head']['sha']
+  end
+
+  def latest_commit_message
+    @top_commit['commit']['message']
   end
 
   def url

--- a/assets/lib/repository.rb
+++ b/assets/lib/repository.rb
@@ -2,11 +2,12 @@ require_relative 'filters/all'
 require_relative 'filters/fork'
 require_relative 'filters/label'
 require_relative 'filters/path'
+require_relative 'filters/ci_skip'
 
 class Repository
   attr_reader :name
 
-  def initialize(name:, input: Input.instance, filters: [Filters::All, Filters::Path, Filters::Fork, Filters::Label])
+  def initialize(name:, input: Input.instance, filters: [Filters::All, Filters::Path, Filters::Fork, Filters::Label, Filters::CISkip])
     @filters = filters
     @name    = name
     @input   = input

--- a/spec/commands/out_spec.rb
+++ b/spec/commands/out_spec.rb
@@ -127,6 +127,8 @@ describe Commands::Out do
                 html_url: 'http://example.com',
                 number: 1,
                 head: { sha: 'abcdef' })
+      stub_json(:get, 'https://api.github.com:443/repos/jtarchie/test/commits/abcdef',
+                sha: "abcdef-#{j}", commit: { message: 'foo bar' })
     end
 
     context 'when setting a status with a comment' do

--- a/spec/filters/label_spec.rb
+++ b/spec/filters/label_spec.rb
@@ -1,14 +1,15 @@
 require_relative '../../assets/lib/filters/label'
 require_relative '../../assets/lib/pull_request'
+require_relative '../../assets/lib/input'
 require 'webmock/rspec'
 
 describe Filters::Label do
   let(:ignore_pr) do
-    PullRequest.new(pr: { 'number' => 1 })
+    PullRequest.new(pr: { 'number' => 1 }, top_commit: {})
   end
 
   let(:pr) do
-    PullRequest.new(pr: { 'number' => 2 })
+    PullRequest.new(pr: { 'number' => 2 }, top_commit: {})
   end
 
   let(:pull_requests) { [ignore_pr, pr] }

--- a/spec/filters/path_spec.rb
+++ b/spec/filters/path_spec.rb
@@ -4,11 +4,11 @@ require 'webmock/rspec'
 
 describe Filters::Path do
   let(:ignore_pr) do
-    PullRequest.new(pr: { 'number' => 1 })
+    PullRequest.new(pr: { 'number' => 1 }, top_commit: {})
   end
 
   let(:pr) do
-    PullRequest.new(pr: { 'number' => 2 })
+    PullRequest.new(pr: { 'number' => 2 }, top_commit: {})
   end
 
   let(:pull_requests) { [ignore_pr, pr] }


### PR DESCRIPTION
We have a frequent PR cadence in our team, and have a pipeline that triggers on every push to an outstanding PR. Which is annoying because it takes up resources. I have added a `[ci skip]` feature which ignores commits that have [ci skip] in them. Similar to how the git-resource works.