### PR TITLE
Add `only_mergeable` feature for `check`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ resource_types:
 * `require_review_approval`: *Optional*, default false.  If set to `true`, it will
   filter out pull requests that do not have an Approved review.
 
-* `require_manual_approval`: *Optional*, default false.  If set to `true`, it will
-  filter out pull requests, unless there is a comment on the PR containing the string
-  `ci ok`, from a collaborator, repo owner, or organization member.
-
 * `authorship_restriction`: *Optional*, default false.  If set to `true`, will only
   return PRs created by someone who is a collaborator, repo owner, or organization member.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ resource_types:
 * `disable_forks`: *Optional*, default false. If set to `true`, it will filter
   out pull requests that were created via users that forked from your repo.
 
+* `only_mergeable`: *Optional*, default false. If set to `true`, it will filter
+  out pull requests that are not mergeable.  A pull request is mergeable if
+  - It has no merge conflicts.
+  - The current user has push permissions to the base repository.
+  - It has at least one review and has been Approved.
+
 * `label`: *Optional.* If set to a string it will only return pull requests that have been
 marked with that specific label. It is case insensitive.
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,17 @@ resource_types:
   out pull requests that were created via users that forked from your repo.
 
 * `only_mergeable`: *Optional*, default false. If set to `true`, it will filter
-  out pull requests that are not mergeable.  A pull request is mergeable if
-  - It has no merge conflicts.
-  - The current user has push permissions to the base repository.
-  - It has at least one review and has been Approved.
+  out pull requests that are not mergeable.  A pull request is mergeable if it has no merge conflicts.
+
+* `require_review_approval`: *Optional*, default false.  If set to `true`, it will
+  filter out pull requests that do not have an Approved review.
+
+* `require_manual_approval`: *Optional*, default false.  If set to `true`, it will
+  filter out pull requests, unless there is a comment on the PR containing the string
+  `ci ok`, from a collaborator, repo owner, or organization member.
+
+* `authorship_restriction`: *Optional*, default false.  If set to `true`, will only
+  return PRs created by someone who is a collaborator, repo owner, or organization member.
 
 * `label`: *Optional.* If set to a string it will only return pull requests that have been
 marked with that specific label. It is case insensitive.

--- a/assets/lib/filters/all.rb
+++ b/assets/lib/filters/all.rb
@@ -9,7 +9,7 @@ module Filters
 
     def pull_requests
       @pull_requests ||= Octokit.pulls(input.source.repo, pull_options).map do |pr|
-        PullRequest.new(pr: pr)
+        PullRequest.new(pr: Octokit.pull_request(input.source.repo, pr['number'], pull_options))
       end
     end
 

--- a/assets/lib/filters/approval.rb
+++ b/assets/lib/filters/approval.rb
@@ -9,9 +9,6 @@ module Filters
       if @input.source.require_review_approval
         @pull_requests.delete_if {|x| !x.review_approved? }
       end
-      if @input.source.require_manual_approval
-        @pull_requests.delete_if {|x| !x.approved_by_collaborator? }
-      end
       if @input.source.authorship_restriction
         @pull_requests.delete_if {|x| !x.author_associated? }
       end

--- a/assets/lib/filters/approval.rb
+++ b/assets/lib/filters/approval.rb
@@ -1,0 +1,22 @@
+module Filters
+  class Approval
+    def initialize(pull_requests:, input: Input.instance)
+      @pull_requests = pull_requests
+      @input = input
+    end
+
+    def pull_requests
+      if @input.source.require_review_approval
+        @pull_requests.delete_if {|x| !x.review_approved? }
+      end
+      if @input.source.require_manual_approval
+        @pull_requests.delete_if {|x| !x.approved_by_collaborator? }
+      end
+      if @input.source.authorship_restriction
+        @pull_requests.delete_if {|x| !x.author_associated? }
+      end
+
+      @pull_requests
+    end
+  end
+end

--- a/assets/lib/filters/approval.rb
+++ b/assets/lib/filters/approval.rb
@@ -7,10 +7,10 @@ module Filters
 
     def pull_requests
       if @input.source.require_review_approval
-        @pull_requests.delete_if {|x| !x.review_approved? }
+        @pull_requests.delete_if { |x| !x.review_approved? }
       end
       if @input.source.authorship_restriction
-        @pull_requests.delete_if {|x| !x.author_associated? }
+        @pull_requests.delete_if { |x| !x.author_associated? }
       end
 
       @pull_requests

--- a/assets/lib/filters/mergeable.rb
+++ b/assets/lib/filters/mergeable.rb
@@ -1,5 +1,5 @@
 module Filters
-  class Mergeable 
+  class Mergeable
     def initialize(pull_requests:, input: Input.instance)
       @pull_requests = pull_requests
       @input = input
@@ -7,7 +7,7 @@ module Filters
 
     def pull_requests
       if @input.source.only_mergeable
-        @memoized ||= @pull_requests.delete_if {|x| !x.mergeable? }
+        @memoized ||= @pull_requests.delete_if { |x| !x.mergeable? }
       else
         @pull_requests
       end

--- a/assets/lib/filters/mergeable.rb
+++ b/assets/lib/filters/mergeable.rb
@@ -1,0 +1,16 @@
+module Filters
+  class Mergeable 
+    def initialize(pull_requests:, input: Input.instance)
+      @pull_requests = pull_requests
+      @input = input
+    end
+
+    def pull_requests
+      if @input.source.only_mergeable
+        @memoized ||= @pull_requests.delete_if {|x| !x.mergeable? }
+      else
+        @pull_requests
+      end
+    end
+  end
+end

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -19,14 +19,14 @@ class PullRequest
   end
 
   def review_approved?
-    Octokit.pull_request_reviews(base_repo, id).any? {|r| r['state'] == 'APPROVED'}
+    Octokit.pull_request_reviews(base_repo, id).any? { |r| r['state'] == 'APPROVED' }
   end
 
   def author_associated?
     # Checks whether the author is associated with the repo that the PR is against:
     # either the owner of that repo, someone invited to collaborate, or a member
     # of the organization who owns that repository.
-    %w(OWNER COLLABORATOR MEMBER).include? @pr['author_association']
+    %w[OWNER COLLABORATOR MEMBER].include? @pr['author_association']
   end
 
   def equals?(id:, sha:)

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -14,6 +14,12 @@ class PullRequest
     base_repo != head_repo
   end
 
+  def mergeable?
+      (@pr['mergeable'] &&
+       @pr['base']['repo']['permissions']['push'] &&
+       Octokit.pull_request_reviews(base_repo, id).any? {|r| r['state'] == 'APPROVED'})
+  end
+
   def equals?(id:, sha:)
     [self.sha, self.id.to_s] == [sha, id.to_s]
   end

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -29,11 +29,6 @@ class PullRequest
     %w(OWNER COLLABORATOR MEMBER).include? @pr['author_association']
   end
 
-  def approved_by_collaborator?
-    Octokit.pull_comments(base_repo, id).any? {|c| (%w(OWNER COLLABORATOR MEMBER).include?(c['author_association']) &&
-                                                    c['body'].downcase.include?('ci ok')) }
-  end
-
   def equals?(id:, sha:)
     [self.sha, self.id.to_s] == [sha, id.to_s]
   end

--- a/assets/lib/repository.rb
+++ b/assets/lib/repository.rb
@@ -4,11 +4,12 @@ require_relative 'filters/label'
 require_relative 'filters/path'
 require_relative 'filters/ci_skip'
 require_relative 'filters/mergeable'
+require_relative 'filters/approval'
 
 class Repository
   attr_reader :name
 
-  def initialize(name:, input: Input.instance, filters: [Filters::All, Filters::Path, Filters::Fork, Filters::Label, Filters::CISkip, Filters::Mergeable])
+  def initialize(name:, input: Input.instance, filters: [Filters::All, Filters::Path, Filters::Fork, Filters::Label, Filters::CISkip, Filters::Mergeable, Filters::Approval])
     @filters = filters
     @name    = name
     @input   = input

--- a/assets/lib/repository.rb
+++ b/assets/lib/repository.rb
@@ -3,11 +3,12 @@ require_relative 'filters/fork'
 require_relative 'filters/label'
 require_relative 'filters/path'
 require_relative 'filters/ci_skip'
+require_relative 'filters/mergeable'
 
 class Repository
   attr_reader :name
 
-  def initialize(name:, input: Input.instance, filters: [Filters::All, Filters::Path, Filters::Fork, Filters::Label, Filters::CISkip])
+  def initialize(name:, input: Input.instance, filters: [Filters::All, Filters::Path, Filters::Fork, Filters::Label, Filters::CISkip, Filters::Mergeable])
     @filters = filters
     @name    = name
     @input   = input

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -85,9 +85,9 @@ describe Commands::Check do
   context 'when there is more than one open pull request' do
     before do
       stub_prs('https://api.github.com/repos/jtarchie/test/pulls?direction=asc&per_page=100&sort=updated&state=open', [
-                  { number: 1, head: { sha: 'abcdef', repo: { full_name: 'jtarchie/test' } }, base: { repo: { full_name: 'jtarchie/test' } } },
-                  { number: 2, head: { sha: 'zyxwvu', repo: { full_name: 'someotherowner/repo' } }, base: { repo: { full_name: 'jtarchie/test' } } }
-                ])
+                 { number: 1, head: { sha: 'abcdef', repo: { full_name: 'jtarchie/test' } }, base: { repo: { full_name: 'jtarchie/test' } } },
+                 { number: 2, head: { sha: 'zyxwvu', repo: { full_name: 'someotherowner/repo' } }, base: { repo: { full_name: 'jtarchie/test' } } }
+               ])
     end
 
     it 'returns all PRs oldest to newest last' do

--- a/spec/filters/approval_spec.rb
+++ b/spec/filters/approval_spec.rb
@@ -1,0 +1,79 @@
+require_relative '../../assets/lib/filters/approval'
+require_relative '../../assets/lib/pull_request'
+require_relative '../../assets/lib/input'
+require 'webmock/rspec'
+
+describe Filters::Approval do
+  let(:ignore_pr) do
+    PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc' }, 'author_association' => 'NONE',
+                          'base' => { 'repo' => {'full_name' => 'user/repo', 'permissions' => {'push' => true} } } })
+  end
+
+  let(:pr) do
+    PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def' }, 'author_association' => 'OWNER',
+                          'base' => { 'repo' => {'full_name' => 'user/repo', 'permissions' => {'push' => true} } } })
+  end
+
+  let(:pull_requests) { [ignore_pr, pr] }
+
+  def stub_json(uri, body)
+    stub_request(:get, uri)
+      .to_return(headers: { 'Content-Type' => 'application/json' }, body: body.to_json)
+  end
+
+  context 'when all approval requirements are disabled' do
+    it 'does not filter' do
+      payload = { 'source' => { 'repo' => 'user/repo' } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq pull_requests
+    end
+
+    it 'does not filter when explictly disabled' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'require_manual_approval' => false, 'require_review_approval' => false, 'authorship_restriction' => false } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq pull_requests
+    end
+  end
+  
+  context 'when owner filtering is enabled' do
+    it 'only returns PRs that are repo-owners' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'require_manual_approval' => false, 'require_review_approval' => false, 'authorship_restriction' => true } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq [pr]
+    end
+  end
+
+  context 'when approval filtering is enabled' do
+    before do
+      stub_json(%r{https://api.github.com/repos/user/repo/pulls/1/reviews}, [{ 'state' => 'CHANGES_REQUESTED' }])
+      stub_json(%r{https://api.github.com/repos/user/repo/pulls/2/reviews}, [{ 'state' => 'APPROVED' }])
+    end
+
+    it 'only returns PRs that are approved' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'require_manual_approval' => false, 'require_review_approval' => true, 'authorship_restriction' => false } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq [pr]
+    end
+  end
+
+  context 'when manual approval filtering is enabled' do
+    before do
+      stub_json(%r{https://api.github.com/repos/user/repo/pulls/1/comments}, [{ 'author_association' => 'OWNER', 'body' => 'other comment' },
+                                                                              { 'author_association' => 'NONE', 'body' => 'ci ok' }])
+      stub_json(%r{https://api.github.com/repos/user/repo/pulls/2/comments}, [{ 'author_association' => 'OWNER', 'body' => 'ci ok' }])
+    end
+
+    it 'only returns PRs that are approved' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'require_manual_approval' => true, 'require_review_approval' => false, 'authorship_restriction' => false } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq [pr]
+    end
+  end
+
+
+end

--- a/spec/filters/approval_spec.rb
+++ b/spec/filters/approval_spec.rb
@@ -60,20 +60,4 @@ describe Filters::Approval do
     end
   end
 
-  context 'when manual approval filtering is enabled' do
-    before do
-      stub_json(%r{https://api.github.com/repos/user/repo/pulls/1/comments}, [{ 'author_association' => 'OWNER', 'body' => 'other comment' },
-                                                                              { 'author_association' => 'NONE', 'body' => 'ci ok' }])
-      stub_json(%r{https://api.github.com/repos/user/repo/pulls/2/comments}, [{ 'author_association' => 'OWNER', 'body' => 'ci ok' }])
-    end
-
-    it 'only returns PRs that are approved' do
-      payload = { 'source' => { 'repo' => 'user/repo', 'require_manual_approval' => true, 'require_review_approval' => false, 'authorship_restriction' => false } }
-      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
-
-      expect(filter.pull_requests).to eq [pr]
-    end
-  end
-
-
 end

--- a/spec/filters/approval_spec.rb
+++ b/spec/filters/approval_spec.rb
@@ -6,12 +6,12 @@ require 'webmock/rspec'
 describe Filters::Approval do
   let(:ignore_pr) do
     PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc' }, 'author_association' => 'NONE',
-                          'base' => { 'repo' => {'full_name' => 'user/repo', 'permissions' => {'push' => true} } } })
+                          'base' => { 'repo' => { 'full_name' => 'user/repo', 'permissions' => { 'push' => true } } } })
   end
 
   let(:pr) do
     PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def' }, 'author_association' => 'OWNER',
-                          'base' => { 'repo' => {'full_name' => 'user/repo', 'permissions' => {'push' => true} } } })
+                          'base' => { 'repo' => { 'full_name' => 'user/repo', 'permissions' => { 'push' => true } } } })
   end
 
   let(:pull_requests) { [ignore_pr, pr] }
@@ -36,7 +36,7 @@ describe Filters::Approval do
       expect(filter.pull_requests).to eq pull_requests
     end
   end
-  
+
   context 'when owner filtering is enabled' do
     it 'only returns PRs that are repo-owners' do
       payload = { 'source' => { 'repo' => 'user/repo', 'require_manual_approval' => false, 'require_review_approval' => false, 'authorship_restriction' => true } }
@@ -59,5 +59,4 @@ describe Filters::Approval do
       expect(filter.pull_requests).to eq [pr]
     end
   end
-
 end

--- a/spec/filters/mergeable_spec.rb
+++ b/spec/filters/mergeable_spec.rb
@@ -5,11 +5,11 @@ require 'webmock/rspec'
 
 describe Filters::Mergeable do
   let(:ignore_pr) do
-    PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc' }, 'mergeable' => false})
+    PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc' }, 'mergeable' => false })
   end
 
   let(:pr) do
-    PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def' }, 'mergeable' => true})
+    PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def' }, 'mergeable' => true })
   end
 
   let(:pull_requests) { [ignore_pr, pr] }

--- a/spec/filters/mergeable_spec.rb
+++ b/spec/filters/mergeable_spec.rb
@@ -1,0 +1,53 @@
+require_relative '../../assets/lib/filters/mergeable'
+require_relative '../../assets/lib/pull_request'
+require_relative '../../assets/lib/input'
+require 'webmock/rspec'
+
+describe Filters::Mergeable do
+  let(:ignore_pr) do
+    PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc' }, 'mergeable' => false,
+                          'base' => { 'repo' => {'full_name' => 'user/repo', 'permissions' => {'push' => true} } } })
+  end
+
+  let(:pr) do
+    PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def' }, 'mergeable' => true ,
+                          'base' => { 'repo' => {'full_name' => 'user/repo', 'permissions' => {'push' => true} } } })
+  end
+
+  let(:pull_requests) { [ignore_pr, pr] }
+
+  def stub_json(uri, body)
+    stub_request(:get, uri)
+      .to_return(headers: { 'Content-Type' => 'application/json' }, body: body.to_json)
+  end
+
+  context 'when mergeable requirement is disabled' do
+    it 'does not filter' do
+      payload = { 'source' => { 'repo' => 'user/repo' } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq pull_requests
+    end
+
+    it 'does not filter when explictly disabled' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'only_mergeable' => false } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq pull_requests
+    end
+  end
+
+  context 'when the mergeable filtering is enabled' do
+    before do
+      stub_json(%r{https://api.github.com/repos/user/repo/pulls/1/reviews}, [{ 'state' => 'CHANGES_REQUESTED' }])
+      stub_json(%r{https://api.github.com/repos/user/repo/pulls/2/reviews}, [{ 'state' => 'APPROVED' }])
+    end
+
+    it 'only returns PRs with that label' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'only_mergeable' => true } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq [pr]
+    end
+  end
+end

--- a/spec/filters/mergeable_spec.rb
+++ b/spec/filters/mergeable_spec.rb
@@ -5,13 +5,11 @@ require 'webmock/rspec'
 
 describe Filters::Mergeable do
   let(:ignore_pr) do
-    PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc' }, 'mergeable' => false,
-                          'base' => { 'repo' => {'full_name' => 'user/repo', 'permissions' => {'push' => true} } } })
+    PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc' }, 'mergeable' => false})
   end
 
   let(:pr) do
-    PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def' }, 'mergeable' => true ,
-                          'base' => { 'repo' => {'full_name' => 'user/repo', 'permissions' => {'push' => true} } } })
+    PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def' }, 'mergeable' => true})
   end
 
   let(:pull_requests) { [ignore_pr, pr] }


### PR DESCRIPTION
Closes #137.

A pull request is mergeable if
- It has no merge conflicts.
- The current user has push permissions to the base repository.
- It has at least one review and has been Approved.

With this option on, only mergeable pull requests will come out of `check`.