### PR TITLE
Implement pulling pull requests which are created from a specific head

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ resource_types:
   linking to builds. On newer versions of Concourse ( >= v0.71.0) , the resource will
   automatically sets the URL.
 
+* `head`: *Optional* When set, will only pull PRs made from a specific branch. The default
+  behaviour is any branch. The value of this property needs to be in the format `user:ref-name`
+  where `user` is the name of the repository where the head is located in, and `ref-name` is the
+  name of the reference (e.g. a branch) of the head.
+
 * `private_key`: *Optional.* Private key to use when pulling/pushing.
     Example:
     ```

--- a/assets/lib/filters/all.rb
+++ b/assets/lib/filters/all.rb
@@ -20,6 +20,9 @@ module Filters
     def pull_options
       options = { state: 'open', sort: 'updated', direction: 'asc' }
       options[:base] = input.source.base if input.source.base
+      if input.source.head
+        options[:head] = input.source.head
+      end
       options
     end
   end

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -26,6 +26,28 @@ describe Commands::Check do
     end
   end
 
+  context 'when targeting head branch other than any' do
+    before do
+      stub_json('https://api.github.com/repos/jtarchie/test/statuses/abcdef', [])
+      stub_json('https://api.github.com:443/repos/jtarchie/test/pulls?base=my-base-branch&head=jtarchie:my-feature-branch&direction=asc&per_page=100&sort=updated&state=open', [{ number: 1, head: { sha: 'abcdef' } }])
+    end
+
+    it 'retrieves pull requests for the specified head branch' do
+      expect(check('source' => { 'repo' => 'jtarchie/test', 'base' => 'my-base-branch', 'head' => 'jtarchie:my-feature-branch' })).to eq [{ 'ref' => 'abcdef', 'pr' => '1' }]
+    end
+  end
+
+  context 'when targeting an invalid head branch' do
+    before do
+      stub_json('https://api.github.com/repos/jtarchie/test/statuses/abcdef', [])
+      stub_json('https://api.github.com:443/repos/jtarchie/test/pulls?head=no-user-in-head&direction=asc&per_page=100&sort=updated&state=open', [])
+    end
+
+    it 'retrieves all pull requests' do
+      expect(check('source' => { 'repo' => 'jtarchie/test', 'head' => 'no-user-in-head' })).to eq []
+    end
+  end
+
   context 'when there are no pull requests' do
     before do
       stub_json('https://api.github.com/repos/jtarchie/test/pulls?direction=asc&per_page=100&sort=updated&state=open', [])


### PR DESCRIPTION
This is the other way around from the base branch option. It will allow to
trigger for pull requests only, which are created from a specific branch.
This can, e.g., used to trigger a specific branch pipeline in concourse for
pull requests, too, without triggering for all other head branches.

Fixes #142 

Based on the github API documentation for the [list pull request api](https://developer.github.com/v3/pulls/#list-pull-requests).