### PR TITLE
Add state filtering to filter on the state of the pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ resource_types:
 * `label`: *Optional.* If set to a string it will only return pull requests that have been
 marked with that specific label. It is case insensitive.
 
+* `state`: *Optional.* If set to a string it will only return pull requests that have this state.
+It is case insensitive.
+
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
   This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)
   and auth is required.

--- a/assets/lib/filters/state.rb
+++ b/assets/lib/filters/state.rb
@@ -1,0 +1,18 @@
+module Filters
+  class State
+    def initialize(pull_requests:, input: Input.instance)
+      @pull_requests = pull_requests
+      @input = input
+    end
+
+    def pull_requests
+      if @input.source.state
+        @memoized ||= @pull_requests.select do |pr|
+          @input.source.state.to_s.casecmp(pr.state.to_s).zero?
+        end
+      else
+        @pull_requests
+      end
+    end
+  end
+end

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -38,6 +38,10 @@ class PullRequest
     @pr['html_url']
   end
 
+  def state
+    @pr['state']
+  end
+
   private
 
   def base_repo

--- a/spec/filters/state_spec.rb
+++ b/spec/filters/state_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../assets/lib/filters/state'
+require_relative '../../assets/lib/pull_request'
+require_relative '../../assets/lib/input'
+require 'webmock/rspec'
+
+describe Filters::State do
+  let(:ignore_pr) do
+    PullRequest.new(pr: { 'number' => 1, 'state' => 'open' })
+  end
+
+  let(:pr) do
+    PullRequest.new(pr: { 'number' => 2, 'state' => 'closed' })
+  end
+
+  let(:pull_requests) { [ignore_pr, pr] }
+
+  def stub_json(uri, body)
+    stub_request(:get, uri)
+      .to_return(headers: { 'Content-Type' => 'application/json' }, body: body.to_json)
+  end
+
+  context 'when no state is specified' do
+    it 'does not filter' do
+      payload = { 'source' => { 'repo' => 'user/repo' } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq pull_requests
+    end
+  end
+
+  context 'when the state for filtering is provided' do
+    it 'only returns PRs with that label' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'state' => 'closed' } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq [pr]
+    end
+  end
+end


### PR DESCRIPTION
Hello,

First and foremost, thanks for your work on this concourse resource, it helps me a lot.

As I use it, I feel it would be nice to allow filtering on the state of the pull request; for example, I would like to trigger a build when one pull request with a specific state and label is closed to clean QA env or some bucket on S3.

Note: I did not find any documentation on possible state so I assume it could be `open`, `closed` or `merged`. Do I have to add this list to the README.md?