### PR TITLE
Store pull request body.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ git config --get pullrequest.userlogin  # returns the github user login for the 
 
  * `.git/head_sha`: the latest commit hash of the branch associated with the pull request
 
+ * `.git/body`: the body of the pull request.
+
 #### Parameters
 
 * `git.depth`: *Optional.* If a positive integer is given, *shallow* clone the

--- a/assets/lib/commands/in.rb
+++ b/assets/lib/commands/in.rb
@@ -28,6 +28,7 @@ module Commands
         system <<-BASH
           echo "#{pr['html_url']}" > url
           echo "#{pr['number']}" > id
+          echo "#{pr['body']}" > body
           echo "#{pr['head']['ref']}" > branch
           echo "#{pr['base']['ref']}" > base_branch
           echo "#{pr['user']['login']}" > userlogin

--- a/spec/commands/in_spec.rb
+++ b/spec/commands/in_spec.rb
@@ -52,7 +52,7 @@ describe Commands::In do
       end
 
       before(:all) do
-        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo', sha: 'hash' }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' })
+        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo', sha: 'hash' }, base: { ref: 'master', user: { login: 'jtarchie' } }, body: 'PR Body', user: { login: 'jtarchie-contributor' })
         @output = get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' })
       end
 
@@ -116,6 +116,11 @@ describe Commands::In do
       it 'creates a file that includes the hash of the branch  in the .git folder' do
         value = File.read(File.join(dest_dir, '.git', 'head_sha')).strip
         expect(value).to eq 'hash'
+      end
+
+      it 'creates a file that contains the PR body in the .git folder' do
+        value = File.read(File.join(dest_dir, '.git', 'body')).strip
+        expect(value).to eq 'PR Body'
       end
     end
 


### PR DESCRIPTION
I use the PR body to decide what to do with the PR - it's already part of the Octokit response to fetching the pull request, so it is easy to store.