### PR TITLE
Add support of concourse build environment in the base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ resource_types:
   linking to builds. On newer versions of Concourse ( >= v0.71.0) , the resource will
   automatically sets the URL.
 
+  This supports the [build environment](http://concourse.ci/implementing-resources.html#resource-metadata)
+  variables provided by concourse. For example, `context: $BUILD_JOB_NAME` will set the context to the job name.
+
 * `private_key`: *Optional.* Private key to use when pulling/pushing.
     Example:
     ```

--- a/assets/lib/commands/out.rb
+++ b/assets/lib/commands/out.rb
@@ -52,7 +52,7 @@ module Commands
       contextes.each do |context|
         Status.new(
           state: params.status,
-          atc_url: atc_url,
+          atc_url: whitelist(context: atc_url),
           sha: sha,
           repo: repo,
           context: whitelist(context: context)

--- a/spec/commands/out_spec.rb
+++ b/spec/commands/out_spec.rb
@@ -39,6 +39,7 @@ describe Commands::Out do
 
     stub_json(:get, "https://api.github.com:443/repos/jtarchie/test/statuses/#{@sha}", [])
     ENV['BUILD_ID'] = '1234'
+    ENV['ATC_EXTERNAL_URL'] = 'default-test-atc-url.com'
   end
 
   def stub_json(method, uri, body)
@@ -233,6 +234,16 @@ describe Commands::Out do
             stub_status_post.with(body: hash_including('target_url' => 'http://example.com/builds/1234'))
 
             put('params' => { 'status' => 'success', 'path' => 'resource' }, 'source' => { 'repo' => 'jtarchie/test', 'base_url' => 'http://example.com' })
+          end
+        end
+
+        context 'with base_url defined on source containing environment variable' do
+          it 'sets the target_url for status' do
+            ENV['BUILD_TEAM_NAME'] = 'build-env-var'
+            stub_status_post.with(body: hash_including('target_url' => 'http://example.com/build-env-var/builds/1234'))
+
+            put('params' => { 'status' => 'success', 'path' => 'resource' }, 'source' => { 'repo' => 'jtarchie/test', 'base_url' => 'http://example.com/$BUILD_TEAM_NAME' })
+            ENV['BUILD_TEAM_NAME'] = nil
           end
         end
 


### PR DESCRIPTION
This commit add the support of build environment from concourse http://concourse.ci/implementing-resources.html#resource-metadata

Using the same function as context.
This will allow to generage your own base_url based on concourse build environment :

```
base_url: foo.com/$BUILD_JOB_NAME
```