### PR TITLE
Add comment_text parameter to add a PR comment using static text

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ Set the status message for `concourse-ci` context on specified pull request.
 
 * `comment`: *Optional.* The file path of the comment message. Comment owner is same with the owner of `access_token`.
 
+* `comment_text`: *Optional.* Static text of the comment message. Comment owner is same with the owner of `access_token`.
+
+  This supports the [build environment](http://concourse.ci/implementing-resources.html#resource-metadata)
+  variables provided by concourse.
+  
+  In addition, if you specify both `comment` and `comment_text`, the `$COMMENT_FILE_CONTENT` variable can be used in 
+  the `comment_text` string to include the contents of the `comment` file with other static text and interpolated 
+  variables.
+
 * `merge.method`: *Optional.* Use this to merge the PR into the target branch of the PR. There are three available merge methods -- `merge`, `squash`, or `rebase`. Please this [doc](https://developer.github.com/changes/2016-09-26-pull-request-merge-api-update/) for more information.
 
 * `merge.commit_msg`: *Optional.* Used with `merge` to set the commit message for the merge. Specify a file path to the merge commit message.

--- a/assets/lib/commands/out.rb
+++ b/assets/lib/commands/out.rb
@@ -59,9 +59,19 @@ module Commands
         ).create!
       end
 
-      if params.comment
-        comment_path = File.join(destination, params.comment)
-        comment = File.read(comment_path, encoding: Encoding::UTF_8)
+      if params.comment || params.comment_text
+        if params.comment
+          comment_path = File.join(destination, params.comment)
+          comment_file_contents = File.read(comment_path, encoding: Encoding::UTF_8)
+        end
+
+        if params.comment_text
+          comment = whitelist(context: params.comment_text)
+          comment.gsub!("$COMMENT_FILE_CONTENT", comment_file_contents || '')
+        else
+          comment = comment_file_contents
+        end
+
         Octokit.add_comment(input.source.repo, id, comment)
         metadata << { 'name' => 'comment', 'value' => comment }
       end


### PR DESCRIPTION
- supports concourse build environment variables and including the comment file as $COMMENT_FILE_CONTENT

Closes #174 