### PR TITLE
Fix bundle exec spec/integration

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -5,6 +5,8 @@ set -e
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+. $(dirname $0)/common.sh
+
 payload=$(mktemp $TMPDIR/pullrequest-resource.XXXXXX)
 cat > $payload <&0
 

--- a/spec/integration/out_spec.rb
+++ b/spec/integration/out_spec.rb
@@ -38,6 +38,7 @@ describe 'out' do
     proxy.stub("https://api.github.com:443/repos/jtarchie/test/statuses/#{@sha}")
          .and_return(json: [])
     ENV['BUILD_ID'] = '1234'
+    ENV['ATC_EXTERNAL_URL'] = 'default-test-atc-url.com'
   end
 
   context 'when the git repo has no pull request meta information' do


### PR DESCRIPTION
For reference, this was done on Linux.