### PR TITLE
ci skip uses head repo, not source repo

### DIFF
--- a/assets/lib/filters/ci_skip.rb
+++ b/assets/lib/filters/ci_skip.rb
@@ -12,7 +12,7 @@ module Filters
         @pull_requests
       else
         @memoized ||= @pull_requests.delete_if do |pr|
-          latest_commit = Octokit.commit(@input.source.repo, pr.sha)
+          latest_commit = Octokit.commit(pr.head_repo, pr.sha)
           latest_commit['commit']['message'] =~ /\[(ci skip|skip ci)\]/
         end
       end

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -51,8 +51,6 @@ class PullRequest
     @pr['html_url']
   end
 
-  private
-
   def base_repo
     @pr['base']['repo']['full_name']
   end

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -67,7 +67,7 @@ describe Commands::Check do
 
     context 'and the top commit has [ci skip] in its message' do
       before do
-        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls?direction=asc&per_page=100&sort=updated&state=open', [{ number: 1, head: { sha: 'abcdef' } }])
+        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls?direction=asc&per_page=100&sort=updated&state=open', [{ number: 1, head: { sha: 'abcdef', repo: { full_name: 'jtarchie/test' } } }])
         stub_json('https://api.github.com:443/repos/jtarchie/test/commits/abcdef', sha: 'abcdef', commit: { message: 'foo [ci skip] bar' })
       end
 

--- a/spec/filters/ci_skip_spec.rb
+++ b/spec/filters/ci_skip_spec.rb
@@ -7,11 +7,11 @@ require 'webmock/rspec'
 
 describe Filters::CISkip do
   let(:ignore_pr) do
-    PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc' } })
+    PullRequest.new(pr: { 'number' => 1, 'head' => { 'sha' => 'abc', 'repo' => { 'full_name' => 'user/repo' } } })
   end
 
   let(:pr) do
-    PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def' } })
+    PullRequest.new(pr: { 'number' => 2, 'head' => { 'sha' => 'def', 'repo' => { 'full_name' => 'user/repo' } } })
   end
 
   let(:pull_requests) { [ignore_pr, pr] }


### PR DESCRIPTION
In the case of a PR coming from a fork, the ci skip code would have
tried to find the commit message for a commit in the source repo, which
is equivalent to the base repo, rather than the head repo, where the
commit actually exists.