### PR TITLE
Support minimum number of approvals merge gate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ resource_types:
 * `require_review_approval`: *Optional*, default false.  If set to `true`, it will
   filter out pull requests that do not have an Approved review.
 
+* `review_approval_count`: *Optional*, default to 1. If the count of approval is lower than `review_approval_count`
+  the pull request is filtered out.
+
 * `authorship_restriction`: *Optional*, default false.  If set to `true`, will only
   return PRs created by someone who is a collaborator, repo owner, or organization member.
 

--- a/assets/lib/filters/approval.rb
+++ b/assets/lib/filters/approval.rb
@@ -11,6 +11,9 @@ module Filters
       if @input.source.require_review_approval
         @pull_requests.delete_if { |x| !x.review_approved? }
       end
+      if @input.source.review_approval_count
+        @pull_requests.delete_if { |x| !x.review_approved_count(@input.source.review_approval_count) }
+      end
       if @input.source.authorship_restriction
         @pull_requests.delete_if { |x| !x.author_associated? }
       end

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -24,7 +24,7 @@ class PullRequest
     if count <= 1
       Octokit.pull_request_reviews(base_repo, id).any? { |r| r['state'] == 'APPROVED' }
     else
-      Octokit.pull_request_reviews(base_repo, id).count { |r| r['state'] == 'APPROVED' } == count
+      Octokit.pull_request_reviews(base_repo, id).count { |r| r['state'] == 'APPROVED' } >= count
     end
   end
 

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -20,6 +20,14 @@ class PullRequest
     Octokit.pull_request_reviews(base_repo, id).any? { |r| r['state'] == 'APPROVED' }
   end
 
+  def review_approved_count(count)
+    if count <= 1
+      Octokit.pull_request_reviews(base_repo, id).any? { |r| r['state'] == 'APPROVED' }
+    else
+      Octokit.pull_request_reviews(base_repo, id).count { |r| r['state'] == 'APPROVED' } == count
+    end
+  end
+
   def author_associated?
     # Checks whether the author is associated with the repo that the PR is against:
     # either the owner of that repo, someone invited to collaborate, or a member

--- a/spec/filters/approval_spec.rb
+++ b/spec/filters/approval_spec.rb
@@ -61,4 +61,25 @@ describe Filters::Approval do
       expect(filter.pull_requests).to eq [pr]
     end
   end
+
+  context 'when approval count filtering is enabled' do
+    before do
+      stub_json(%r{https://api.github.com/repos/user/repo/pulls/1/reviews}, [{ 'state' => 'CHANGES_REQUESTED' }])
+      stub_json(%r{https://api.github.com/repos/user/repo/pulls/2/reviews}, [{ 'state' => 'APPROVED' }, {'state' => 'APPROVED' }])
+    end
+
+    it 'only returns PRs that are approved twice' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'require_manual_approval' => false, 'require_review_approval' => true, 'review_approval_count' => 2, 'authorship_restriction' => false } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq [pr]
+    end
+
+    it 'returns nothing' do
+      payload = { 'source' => { 'repo' => 'user/repo', 'require_manual_approval' => false, 'require_review_approval' => true, 'review_approval_count' => 5, 'authorship_restriction' => false } }
+      filter = described_class.new(pull_requests: pull_requests, input: Input.instance(payload: payload))
+
+      expect(filter.pull_requests).to eq []
+    end
+  end
 end


### PR DESCRIPTION
# Why?
To go inline with new Github merge gate to require a minimum number of approvals, I've added a new filter called `review_approval_count` which delete the pr from valid input if the count of approvals is not greater or equal.

# Test failure

(Even from MASTER) I always get this failure and I have no idea why, but since it also fails on master I guess it's probably something on my local setup.

```ruby
Failures:

  1) check when working with an external API makes requests with respect to that endpoint
     Failure/Error: JSON.parse(output)
     
     JSON::ParserError:
       743: unexpected token at ''
     # ./spec/integration/check_spec.rb:12:in `check'
     # ./spec/integration/check_spec.rb:25:in `block (3 levels) in <top (required)>'

Finished in 7.14 seconds (files took 0.66294 seconds to load)
85 examples, 1 failure

Failed examples:

rspec ./spec/integration/check_spec.rb:21 # check when working with an external API makes requests with respect to that endpoint
```

# Notes
- My code is not perfect, I'm happy to improve on feedback! Just don't be a dick about my ruby, I know about it :P
- I could have implemented a trigger on reviews but I doubt this is the general direction of this resource.