### PR TITLE
Config should include the head repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ git config --get pullrequest.body       # returns the PR body
 git config --get pullrequest.basebranch # returns the base branch used for the pull request
 git config --get pullrequest.basesha    # returns the commit of the base branch used for the pull request
 git config --get pullrequest.userlogin  # returns the github user login for the pull request author
+git config --get pullrequest.repo       # returns the full name of the source repo of the PR.
 ```
 
 
@@ -145,6 +146,8 @@ git config --get pullrequest.userlogin  # returns the github user login for the 
  * `.git/head_sha`: the latest commit hash of the branch associated with the pull request
 
  * `.git/body`: the body of the pull request.
+
+ * `.git/repo`: the full name of the source repo of the PR.
 
 #### Parameters
 

--- a/assets/lib/commands/in.rb
+++ b/assets/lib/commands/in.rb
@@ -35,6 +35,7 @@ module Commands
         File.write('base_sha', pr['base']['sha'])
         File.write('userlogin', pr['user']['login'])
         File.write('head_sha', pr['head']['sha'])
+        File.write('repo', pr['head']['repo']['full_name'])
       end
 
       Dir.chdir(destination) do
@@ -49,6 +50,7 @@ module Commands
           git config --add pullrequest.basebranch #{pr['base']['ref'].to_s.shellescape} 1>&2
           git config --add pullrequest.basesha #{pr['base']['sha'].to_s.shellescape} 1>&2
           git config --add pullrequest.userlogin #{pr['user']['login'].to_s.shellescape} 1>&2
+          git config --add pullrequest.repo #{pr['head']['repo']['full_name'].to_s.shellescape} 1>&2
         BASH
 
         case input.params.git.submodules

--- a/spec/commands/in_spec.rb
+++ b/spec/commands/in_spec.rb
@@ -59,7 +59,8 @@ describe Commands::In do
                   number: 1,
                   head: {
                     ref: 'foo',
-                    sha: 'hash'
+                    sha: 'hash',
+                    repo: { full_name: 'repo/name' }
                   },
                   base: {
                     ref: 'master',
@@ -173,7 +174,7 @@ describe Commands::In do
     context 'and fetch_merge is false' do
       it 'checks out as a branch named in the PR' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo', repo: { full_name: 'repo/name' } }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: true)
 
         get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => false })
 
@@ -183,7 +184,7 @@ describe Commands::In do
 
       it 'does not fail cloning' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo', repo: { full_name: 'repo/name' } }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: true)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => false })
@@ -194,7 +195,7 @@ describe Commands::In do
     context 'and fetch_merge is true' do
       it 'checks out the branch the PR would be merged into' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo', repo: { full_name: 'repo/name' } }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: true)
 
         get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params:' => { 'fetch_merge' => true })
 
@@ -204,7 +205,7 @@ describe Commands::In do
 
       it 'does not fail cloning' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo', repo: { full_name: 'repo/name' } }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: true)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => true })
@@ -217,7 +218,7 @@ describe Commands::In do
     context 'and fetch_merge is true' do
       it 'raises a helpful error message' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: false)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo', repo: { full_name: 'repo/name' } }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' }, mergeable: false)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => true })
@@ -230,7 +231,7 @@ describe Commands::In do
     before do
       stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
                 html_url: 'http://example.com', number: 1,
-                head: { ref: 'foo' },
+                head: { ref: 'foo', repo: { full_name: 'repo/name' } },
                 base: { ref: 'master', user: { login: 'jtarchie' } },
                 user: { login: 'jtarchie-contributor' })
     end

--- a/spec/integration/in_spec.rb
+++ b/spec/integration/in_spec.rb
@@ -37,7 +37,7 @@ describe 'get' do
   context 'for every PR that is checked out' do
     before do
       proxy.stub('https://api.github.com:443/repos/jtarchie/test/pulls/1')
-           .and_return(json: { html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' } })
+           .and_return(json: { html_url: 'http://example.com', number: 1, head: { ref: 'foo', repo: { full_name: 'repo/name' } }, base: { ref: 'master', user: { login: 'jtarchie' } }, user: { login: 'jtarchie-contributor' } })
     end
 
     it 'checks out the pull request to dest_dir' do


### PR DESCRIPTION
This implements #194.  It's just a simple addition of the HTTP response's `['head']['repo']['full_name']` to the git config and the .git folder as `repo`.